### PR TITLE
Add external plugin loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,32 @@ export const logicMap = {
 };
 ```
 
-### 3. 支持的输入类型
+### 4. JavaScript 插件
+
+除了在 `src/content/tools/` 中定义工具外，也可以通过加载外部 JS 插件的方式扩展功能。
+插件需导出一个对象，其中包含工具的元数据以及 `run` 函数：
+
+```javascript
+// public/plugins/sample.js
+export default {
+  id: 'sample',
+  title: '示例插件',
+  description: '通过 JS 文件加载的外部工具',
+  inputs: [
+    { id: 'text', type: 'text', label: '文本' }
+  ],
+  outputs: [
+    { id: 'result', type: 'text', label: '结果' }
+  ],
+  async run({ text }) {
+    return { result: text.toUpperCase() };
+  }
+};
+```
+
+访问 `/load?src=/plugins/sample.js` 即可在浏览器中运行该插件。
+
+### 5. 支持的输入类型
 
 | 类型 | 描述 | 支持属性 |
 |------|------|----------|
@@ -211,7 +236,7 @@ export const logicMap = {
 | `select` | 下拉选择 | `options`, `defaultValue` |
 | `checkbox` | 复选框 | `defaultValue` |
 
-### 4. 支持的输出类型
+### 6. 支持的输出类型
 
 | 类型 | 描述 | 渲染方式 |
 |------|------|----------|

--- a/public/plugins/sample.js
+++ b/public/plugins/sample.js
@@ -1,0 +1,14 @@
+export default {
+  id: 'sample',
+  title: '示例插件',
+  description: '这是一个外部加载的示例插件',
+  inputs: [
+    { id: 'text', type: 'text', label: '输入文本' }
+  ],
+  outputs: [
+    { id: 'result', type: 'text', label: '处理结果' }
+  ],
+  async run({ text }) {
+    return { result: text.split('').reverse().join('') };
+  }
+};

--- a/src/lib/pluginLoader.ts
+++ b/src/lib/pluginLoader.ts
@@ -1,0 +1,58 @@
+// Dynamic plugin loader
+// 动态加载外部插件
+
+export interface PluginTool {
+  data: {
+    id: string;
+    title: string;
+    description: string;
+    category?: string;
+    tags?: string[];
+    inputs: Array<{
+      id: string;
+      type: string;
+      label: string;
+      placeholder?: string;
+      required?: boolean;
+      accept?: string[];
+      options?: Array<{ value: string; label: string }>;
+      min?: number;
+      max?: number;
+      step?: number;
+      defaultValue?: any;
+    }>;
+    outputs: Array<{
+      id: string;
+      type: string;
+      label: string;
+      reversible?: boolean;
+    }>;
+    logic?: string;
+    reversible?: boolean;
+    reverseMapping?: Array<{
+      from: string;
+      to: string;
+      type?: 'direct' | 'transform';
+    }>;
+  };
+  run: (inputs: any) => Promise<any>;
+}
+
+/**
+ * Dynamically load a JavaScript plugin.
+ *
+ * @param url Plugin file URL
+ */
+export async function loadPlugin(url: string): Promise<PluginTool> {
+  const mod = await import(/* @vite-ignore */ url);
+  const plugin = (mod.default ?? mod) as any;
+  if (!plugin || typeof plugin.run !== 'function') {
+    throw new Error('Invalid plugin: missing run function');
+  }
+
+  const { run, ...data } = plugin;
+  return {
+    data,
+    run,
+  } as PluginTool;
+}

--- a/src/pages/load.astro
+++ b/src/pages/load.astro
@@ -1,0 +1,14 @@
+---
+import ToolPage from '../layouts/ToolPage.astro';
+import ToolRunner from '../components/ToolRunner.tsx';
+
+const src = Astro.url.searchParams.get('src');
+---
+
+<ToolPage title="加载插件" description="通过 URL 加载外部插件">
+  {src ? (
+    <ToolRunner pluginUrl={src} client:only="react" />
+  ) : (
+    <p class="text-center py-8">缺少 <code>src</code> 参数</p>
+  )}
+</ToolPage>


### PR DESCRIPTION
## Summary
- load external tool plugins using `loadPlugin`
- allow ToolRunner to consume plugin URL
- create `/load` route for plugin execution
- document plugin usage and example
- add sample plugin file

## Testing
- `pnpm build` *(fails: Request was cancelled due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_6853f5bc1d7c8324acb73d636d41d8c2