### PR TITLE
Add external plugin loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,32 @@ export const logicMap = {
 };
 ```
 
-### 3. 支持的输入类型
+### 4. JavaScript 插件
+
+除了在 `src/content/tools/` 中定义工具外，也可以通过加载外部 JS 插件的方式扩展功能。
+插件需导出一个对象，其中包含工具的元数据以及 `run` 函数：
+
+```javascript
+// public/plugins/sample.js
+export default {
+  id: 'sample',
+  title: '示例插件',
+  description: '通过 JS 文件加载的外部工具',
+  inputs: [
+    { id: 'text', type: 'text', label: '文本' }
+  ],
+  outputs: [
+    { id: 'result', type: 'text', label: '结果' }
+  ],
+  async run({ text }) {
+    return { result: text.toUpperCase() };
+  }
+};
+```
+
+访问 `/load?src=/plugins/sample.js` 即可在浏览器中运行该插件。
+
+### 5. 支持的输入类型
 
 | 类型 | 描述 | 支持属性 |
 |------|------|----------|
@@ -211,7 +236,7 @@ export const logicMap = {
 | `select` | 下拉选择 | `options`, `defaultValue` |
 | `checkbox` | 复选框 | `defaultValue` |
 
-### 4. 支持的输出类型
+### 6. 支持的输出类型
 
 | 类型 | 描述 | 渲染方式 |
 |------|------|----------|

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ export default {
 ```
 
 在浏览器中打开 [`/load?src=/plugins/sample.js`](./load?src=/plugins/sample.js) 即可运行该插件。
+如果未提供 src 参数，页面会提示 “缺少 src 参数”
 
 ### 5. 支持的输入类型
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ export default {
 };
 ```
 
-访问 `/load?src=/plugins/sample.js` 即可在浏览器中运行该插件。
+在浏览器中打开 [`/load?src=/plugins/sample.js`](./load?src=/plugins/sample.js) 即可运行该插件。
 
 ### 5. 支持的输入类型
 

--- a/public/plugins/sample.js
+++ b/public/plugins/sample.js
@@ -1,0 +1,14 @@
+export default {
+  id: 'sample',
+  title: '示例插件',
+  description: '这是一个外部加载的示例插件',
+  inputs: [
+    { id: 'text', type: 'text', label: '输入文本' }
+  ],
+  outputs: [
+    { id: 'result', type: 'text', label: '处理结果' }
+  ],
+  async run({ text }) {
+    return { result: text.split('').reverse().join('') };
+  }
+};

--- a/src/components/PluginLoader.tsx
+++ b/src/components/PluginLoader.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ToolRunner from './ToolRunner';
+
+export default function PluginLoader() {
+  const [pluginUrl, setPluginUrl] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const src = params.get('src');
+    if (src) setPluginUrl(src);
+  }, []);
+
+  if (!pluginUrl) {
+    return <p className="text-center py-8">缺少 <code>src</code> 参数</p>;
+  }
+
+  return <ToolRunner pluginUrl={pluginUrl} />;
+}

--- a/src/layouts/ToolPage.astro
+++ b/src/layouts/ToolPage.astro
@@ -49,6 +49,9 @@ const { title, description } = Astro.props;
             <a href="/tools" class="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium transition-colors">
               所有工具
             </a>
+            <a href="/load?src=/plugins/sample.js" class="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium transition-colors">
+              加载插件
+            </a>
             <a href="/about" class="text-gray-600 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium transition-colors">
               关于
             </a>

--- a/src/lib/pluginLoader.ts
+++ b/src/lib/pluginLoader.ts
@@ -1,0 +1,58 @@
+// Dynamic plugin loader
+// 动态加载外部插件
+
+export interface PluginTool {
+  data: {
+    id: string;
+    title: string;
+    description: string;
+    category?: string;
+    tags?: string[];
+    inputs: Array<{
+      id: string;
+      type: string;
+      label: string;
+      placeholder?: string;
+      required?: boolean;
+      accept?: string[];
+      options?: Array<{ value: string; label: string }>;
+      min?: number;
+      max?: number;
+      step?: number;
+      defaultValue?: any;
+    }>;
+    outputs: Array<{
+      id: string;
+      type: string;
+      label: string;
+      reversible?: boolean;
+    }>;
+    logic?: string;
+    reversible?: boolean;
+    reverseMapping?: Array<{
+      from: string;
+      to: string;
+      type?: 'direct' | 'transform';
+    }>;
+  };
+  run: (inputs: any) => Promise<any>;
+}
+
+/**
+ * Dynamically load a JavaScript plugin.
+ *
+ * @param url Plugin file URL
+ */
+export async function loadPlugin(url: string): Promise<PluginTool> {
+  const mod = await import(/* @vite-ignore */ url);
+  const plugin = (mod.default ?? mod) as any;
+  if (!plugin || typeof plugin.run !== 'function') {
+    throw new Error('Invalid plugin: missing run function');
+  }
+
+  const { run, ...data } = plugin;
+  return {
+    data,
+    run,
+  } as PluginTool;
+}

--- a/src/pages/load.astro
+++ b/src/pages/load.astro
@@ -1,0 +1,14 @@
+---
+import ToolPage from '../layouts/ToolPage.astro';
+import ToolRunner from '../components/ToolRunner.tsx';
+
+const src = Astro.url.searchParams.get('src');
+---
+
+<ToolPage title="加载插件" description="通过 URL 加载外部插件">
+  {src ? (
+    <ToolRunner pluginUrl={src} client:only="react" />
+  ) : (
+    <p class="text-center py-8">缺少 <code>src</code> 参数</p>
+  )}
+</ToolPage>

--- a/src/pages/load.astro
+++ b/src/pages/load.astro
@@ -1,14 +1,8 @@
 ---
 import ToolPage from '../layouts/ToolPage.astro';
-import ToolRunner from '../components/ToolRunner.tsx';
-
-const src = Astro.url.searchParams.get('src');
+import PluginLoader from '../components/PluginLoader.tsx';
 ---
 
 <ToolPage title="加载插件" description="通过 URL 加载外部插件">
-  {src ? (
-    <ToolRunner pluginUrl={src} client:only="react" />
-  ) : (
-    <p class="text-center py-8">缺少 <code>src</code> 参数</p>
-  )}
+  <PluginLoader client:only="react" />
 </ToolPage>


### PR DESCRIPTION
## Summary
- load external tool plugins using `loadPlugin`
- allow ToolRunner to consume plugin URL
- create `/load` route for plugin execution
- document plugin usage and example
- add sample plugin file

## Testing
- `pnpm build` *(fails: Request was cancelled due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_6853f5bc1d7c8324acb73d636d41d8c2